### PR TITLE
Add WebGPU build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+raylib_c_project
+*.o
+web/

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@ CFLAGS = -Wall -Wextra -O2 -I/usr/local/include -DPLATFORM_DESKTOP
 #       For macOS, it might be: -lraylib -framework CoreVideo -framework IOKit -framework Cocoa -framework GLUT -framework OpenGL
 LDFLAGS = -L/usr/local/lib -lraylib -lm -lpthread -ldl -lrt -lX11
 
+# Web target settings
+EMCC = emcc
+WEB_DIR = web
+WEB_TARGET = $(WEB_DIR)/index.html
+CFLAGS_WEB = -Os -I/usr/local/include -DPLATFORM_WEB -s USE_WEBGPU=1
+LDFLAGS_WEB = -L/usr/local/lib -lraylib --preload-file shaders
+
 # Default target
 all: $(TARGET)
 
@@ -43,5 +50,12 @@ clean:
 run: $(TARGET)
 	./$(TARGET)
 
+# Build WebAssembly version using WebGPU
+web: $(WEB_TARGET)
+
+$(WEB_TARGET): $(SRCS)
+	mkdir -p $(WEB_DIR)
+	$(EMCC) $(SRCS) -o $(WEB_TARGET) $(CFLAGS_WEB) $(LDFLAGS_WEB)
+
 # Phony targets (targets that are not files)
-.PHONY: all clean run
+.PHONY: all clean run web

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ A `Makefile` is provided. You need raylib and a C compiler installed. On many Li
 ```bash
 make       # builds `raylib_c_project`
 make run   # builds and runs the program
+make web   # builds a WebAssembly/WebGPU version
 ```
 
 Alternatively, `./run.sh` cleans, rebuilds and runs the program.
+
+### Building for the web
+
+The `make web` target uses the Emscripten toolchain with WebGPU enabled. You need
+Emscripten and a WebGPU capable build of raylib. Running `make web` produces
+`web/index.html` together with the required assets. Serve that directory with any
+static file server to test in a browser.
 
 ## Files
 


### PR DESCRIPTION
## Summary
- ignore build outputs
- add WebGPU compile target using `emcc`
- document web build in README

## Testing
- `make web` *(fails: emcc missing)*
- `make` *(fails: raylib.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877a8484844832ca701b8b57af71768